### PR TITLE
Fix (some) false negatives

### DIFF
--- a/plugin/lint.js
+++ b/plugin/lint.js
@@ -59,9 +59,19 @@
       // Detects expressions of the form `object.property`
       MemberExpression: function(node, state, c) {
         var type = infer.expressionType({node: node, state: state});
-        if(type.isEmpty()) {
+        var parentType = infer.expressionType({node: node.object, state: state});
+        
+        if(!parentType.isEmpty() && type.isEmpty()) {
           // The type of the property cannot be determined, which means
           // that the property probably doesn't exist.
+
+          // We only do this check if the parent type is known,
+          // otherwise we will generate errors for an entire chain of unknown
+          // properties.
+
+          // Also, the expression may be valid even if the parent type is unknown,
+          // since the inference engine cannot detect the type in all cases.
+          
           var error = makeError(node, "Unknown property '" + getName(node) + "'");
           messages.push(error);
         }

--- a/test/run.js
+++ b/test/run.js
@@ -20,17 +20,14 @@ exports['test Unknown property'] = function() {
 }
 
 exports['test Unknown property + identifier'] = function() {
-	// without 'browser' def, document is not known, and getElementById too
+	// without 'browser' def, document is not known
+	// The check does not continue to getElementById, since
+	// the real cause is that document is undefined.
 	util.assertLint("var elt = document.getElementById('myId');", {
 		messages : [ {
 			"message" : "Unknown identifier 'document'",
 			"from" : 10,
 			"to" : 18,
-			"severity" : "warning"
-		}, {
-			"message" : "Unknown property 'getElementById'",
-			"from" : 19,
-			"to" : 33,
 			"severity" : "warning"
 		} ]
 	});
@@ -93,6 +90,24 @@ exports['test functions parameters'] = function() {
 	});
 }
 
+
+exports['test properties on functions parameters'] = function() {
+	// In this case the type of `a` is inferred as an object with a property `len`.
+	util.assertLint("function test(a) { var len = a.len; }; test({len: 5});", {
+		messages : [ ]
+	});
+
+	// In this case the type of `a` is unknown, and should not produce warnings
+	// on any of its properties.
+	util.assertLint("function test(a) { var len = a.len; };", {
+		messages : [ ]
+	});
+
+	// The same goes for function calls on an unknown type
+	util.assertLint("function test(a) { var len = a.myLength(); };", {
+		messages : [ ]
+	});
+}
 
 
 if (module == require.main)


### PR DESCRIPTION
This fixes some false negatives I've found during testing.
1. `infer.scopeAt()` turned out to not be very reliable at finding the correct function scope, in addition to probably being slow for large files. The walk process was modified to keep track of the scope of function calls. I'm not sure if the current implementation is 100% correct for all cases, but it passes the test cases that were failing previously.
2. In some cases the type of an identifier may be unknown, even though the variable is defined. An common example is function parameters. The logic was changed to not complain if there is an `originNode` for the type of the identifier.
3. The logic on properties was changed to only warn if the parent (object) type is known. A warning will be displayed on the parent if it's really an error. This also reduces false negatives when the parent type is not known but potentially valid.

I added tests for all the cases. Also note that the `test Unknown property + identifier` test now produces one less warning.
