### PR TITLE
Fix some false negatives for properties with unknown type, try 2

### DIFF
--- a/plugin/lint.js
+++ b/plugin/lint.js
@@ -81,12 +81,15 @@
           var propertyDefined = false;
 
           // In some cases the type is unknown, even if the property is defined
-          if(parentType.props) {
-            // We cannot use parentType.getProp(), since this could return
-            // something even for undefined properties.
-            if(node.property.name in parentType.props) {
-              propertyDefined = true;
-            }
+          if(parentType.types) {
+            // We cannot use parentType.hasProp or parentType.props - in the case of an AVal,
+            // this may contain properties that are not really defined.
+            parentType.types.forEach(function(potentialType) {
+              // Obj#hasProp checks the prototype as well
+              if(typeof potentialType.hasProp == 'function' && potentialType.hasProp(node.property.name, true)) {
+                propertyDefined = true;
+              }
+            });
           }
 
           if(!propertyDefined) {

--- a/test/run.js
+++ b/test/run.js
@@ -111,12 +111,34 @@ exports['test properties on functions parameters'] = function() {
 
 
 exports['test assignment of unknown value'] = function() {
+
+	util.assertLint("var a = {}; function test(p) { var b = a.b; };", {
+		messages : [ {
+			"message": "Unknown property 'b'",
+			"from": 41,
+			"to": 42,
+			"severity": "warning"} ]
+	});
+
 	// The type of a.t is unknown, but it is still a valid property.
-	util.assertLint("var a = {}; function test(p) { a.t = p; var b = a.t; };", {
+	util.assertLint("var a = {}; function test(p) { a.t = p; var b = a.t; }", {
 		messages : [ ]
 	});
 
-	util.assertLint("var a = {t: 5}; function test(p) { a.t = p; };", {
+	util.assertLint("var a = {}; function test(p) { a.t = p; }", {
+		messages : [ ]
+	});
+
+	// This should only contain a warning for `notdefined`, not for b = a.val.
+	util.assertLint("function A() {}; A.prototype.val = notdefined; var a = new A(); var b = a.val;", {
+		messages : [ {
+			"message": "Unknown identifier 'notdefined'",
+			"from": 35,
+			"to": 45,
+			"severity": "warning"} ]
+	});
+
+	util.assertLint("var a = {t: 5}; function test(p) { a.t = p; }", {
 		messages : [ ]
 	});
 }


### PR DESCRIPTION
If one of the potential types of the member's parent defines the property, we don't warn, even if the type is unknown.

This checks through the prototype chains as well.

Fixes #12.
