### PR TITLE
Don't validate computed properties (bracket notation).

### DIFF
--- a/plugin/lint.js
+++ b/plugin/lint.js
@@ -66,6 +66,12 @@
       MemberExpression: function(node, state, c) {
         var type = infer.expressionType({node: node, state: state});
         var parentType = infer.expressionType({node: node.object, state: state});
+
+        if(node.computed) {
+          // Bracket notation.
+          // Until we figure out how to handle these properly, we ignore these nodes.
+          return;
+        }
         
         if(!parentType.isEmpty() && type.isEmpty()) {
           // The type of the property cannot be determined, which means

--- a/test/run.js
+++ b/test/run.js
@@ -143,5 +143,16 @@ exports['test assignment of unknown value'] = function() {
 	});
 }
 
+exports['test dynamic properties (bracket notation)'] = function() {
+	util.assertLint("var obj = { test: 1 }; var key = 'test'; var val1 = obj[key]; var val2 = obj['test'];", {
+		messages : [ ]
+	});
+
+	util.assertLint("var obj = { test: function() {} }; var key = 'test'; obj[key](); obj['test']();", {
+		messages : [ ]
+	});
+}
+
+
 if (module == require.main)
 	require('test').run(exports)


### PR DESCRIPTION
Fixes #11.

This will also ignore simpler cases like `obj['invalid_property']`, but I believe it's better to just ignore any bracket notation properties until we figure out how to handle them properly.
