### PR TITLE
Type check object literals declared before typed function call

### DIFF
--- a/demos/OL_DeclaredBeforeFunction_Issue22.html
+++ b/demos/OL_DeclaredBeforeFunction_Issue22.html
@@ -1,0 +1,153 @@
+<!doctype html>
+
+<title>CodeMirror: Tern Demo</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="codemirror/doc/docs.css">
+
+<!-- CodeMirror -->
+    <link rel="stylesheet" href="codemirror/lib/codemirror.css">
+    <script src="codemirror/lib/codemirror.js"></script>
+    <link rel="stylesheet" href="codemirror/theme/eclipse.css">
+    <script src="codemirror/addon/edit/closetag.js"></script>
+    <script src="codemirror/addon/edit/closebrackets.js"></script>
+    <script src="codemirror/addon/edit/matchbrackets.js"></script>
+    <script src="codemirror/addon/selection/active-line.js"></script>
+    <script src="codemirror/addon/runmode/runmode.js"></script>
+    <script src="codemirror/mode/javascript/javascript.js"></script>
+
+    <script src="codemirror/addon/lint/lint.js"></script>
+    <link rel="stylesheet" href="codemirror/addon/lint/lint.css">
+
+
+<script>
+var defs = [];
+CodeMirror.tern = {};
+CodeMirror.tern.addDef = function(def) {
+	defs.push(def);
+}
+</script>
+    <script src="codemirror-javascript/addon/hint/tern/defs/ecma5.json.js"></script>
+    <script src="codemirror-javascript/addon/hint/tern/defs/browser.json.js"></script>
+    <script src="codemirror-javascript/addon/hint/tern/defs/chrome-apps.json.js"></script>
+
+  <!-- Tern JS -->
+  <script src="ternjs/acorn/acorn.js"></script>
+  <script src="	ternjs/acorn/acorn_loose.js"></script>
+  <script src="ternjs/acorn/util/walk.js"></script>
+  <script src="ternjs/tern/lib/signal.js"></script>
+  <script src="ternjs/tern/lib/tern.js"></script>
+  <script src="ternjs/tern/lib/def.js"></script>
+  <script src="ternjs/tern/lib/comment.js"></script>
+  <script src="ternjs/tern/lib/infer.js"></script>
+
+  <!-- Official CodeMirror Tern addon -->
+  <script src="codemirror/addon/tern/tern.js"></script>
+
+<link rel="stylesheet" href="codemirror/addon/dialog/dialog.css">
+<link rel="stylesheet" href="codemirror/addon/hint/show-hint.css">
+<link rel="stylesheet" href="codemirror/addon/tern/tern.css">
+<script src="codemirror/addon/dialog/dialog.js"></script>
+<script src="codemirror/addon/hint/show-hint.js"></script>
+<script src="codemirror/addon/tern/tern.js"></script>
+
+<!--  Tern Lint -->
+  <script src="../codemirror/addon/lint/tern-lint.js"></script>
+  <script src="../lint.js"></script>
+
+<style>
+      .CodeMirror {border: 1px solid #ddd;}
+    </style>
+<div id=nav>
+  <a href="http://codemirror.net"><img id=logo src="codemirror/doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../index.html">Home</a>
+    <li><a href="../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/marijnh/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a class=active href="#">Tern</a>
+  </ul>
+</div>
+
+<article>
+<h2>Tern Lint Demo</h2>
+<form><textarea id="code" name="code">
+// A Property that is unknown: anInvalidOption
+var obj1 = {anInvalidOption: 'foo'};
+chrome.app.window.create('index.html', obj1);
+
+// A Property that does not type check, (hidden should be a bool)
+var obj2 = {hidden: 'foo'};
+chrome.app.window.create('index.html', obj2);
+
+// A Property that is of the correct type => OK
+var obj3 = {id: 'fooID'};
+chrome.app.window.create('index.html', obj3);
+
+// multiple Properties of the correct type => OK
+var obj4 = {id: 'fooID',hidden: true};
+chrome.app.window.create('index.html', obj4);
+
+// one bad one mixed in
+var obj5 = {id: 'fooID', oho: 34, hidden: true};
+chrome.app.window.create('index.html', obj5);
+
+// id is forward declared object literal but it should be string
+var lit = {foo: 400};
+document.getElementById(lit);
+</textarea></p>
+
+<p>Demonstrates integration of <a href="http://ternjs.net/">Tern</a>
+and CodeMirror. The following keys are bound:</p>
+
+<dl>
+  <dt>Ctrl-Space</dt><dd>Autocomplete</dd>
+  <dt>Ctrl-I</dt><dd>Find type at cursor</dd>
+  <dt>Alt-.</dt><dd>Jump to definition (Alt-, to jump back)</dd>
+  <dt>Ctrl-Q</dt><dd>Rename variable</dd>
+</dl>
+
+<p>Documentation is sparse for now. See the top of
+the <a href="codemirror/addon/tern/tern.js">script</a> for a rough API
+overview.</p>
+
+<script>
+
+  function getURL(url, c) {
+    var xhr = new XMLHttpRequest();
+    xhr.open("get", url, true);
+    xhr.send();
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState != 4) return;
+      if (xhr.status < 400) return c(null, xhr.responseText);
+      var e = new Error(xhr.responseText || "No response");
+      e.status = xhr.status;
+      c(e);
+    };
+  }
+
+  var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
+    lineNumbers: true,
+    mode: "javascript"
+  });
+
+  //var server;
+  //getURL("http://ternjs.net/defs/ecma5.json", function(err, code) {
+  //  if (err) throw new Error("Request for ecma5.json: " + err);
+  var server = new CodeMirror.TernServer({defs: defs, plugins:{"lint":"../"}});
+    editor.setOption("extraKeys", {
+      "Ctrl-Space": function(cm) { server.complete(cm); },
+      "Ctrl-I": function(cm) { server.showType(cm); },
+      "Alt-.": function(cm) { server.jumpToDef(cm); },
+      "Alt-,": function(cm) { server.jumpBack(cm); },
+      "Ctrl-Q": function(cm) { server.rename(cm); },
+    })
+    editor.setOption("gutters",["CodeMirror-lint-markers"]);
+    editor.setOption("lint", {getAnnotations: CodeMirror.ternLint, async : true, server: server})
+    editor.on("cursorActivity", function(cm) { server.updateArgHints(cm); });
+  //});
+
+</script>
+
+  </article>

--- a/test/run.js
+++ b/test/run.js
@@ -213,6 +213,13 @@ exports['test type-checking of object literals declared before a function with a
   util.assertLint("var obj5 = {id: 'fooID', oho: 34, hidden: true}; chrome.app.window.create('index.html', obj5);", {
     "messages":[{"message":"Invalid argument at 2: oho is not a property in CreateWindowOptions","from":25,"to":28,"severity":"error"}]
   }, [ "chrome_apps" ]);
+
+  // id is forward declared object literal but it should be string
+  util.assertLint("var lit = {foo: 400}; document.getElementById(lit);", {
+          messages : [ {
+            "message":"Invalid argument at 1: cannot convert from Object.prototype to String.prototype","from":46,"to":49,"severity":"error"
+          }]
+  }, [ "browser" ]);
 }
 
 exports['test Invalid Argument'] = function() {


### PR DESCRIPTION
This code can now type check object literals that are declared before the function call, often because they are large enough to make a function call look messy.
