### PR TITLE
Less false warnings about "not a function" when we're not sure.

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -215,7 +215,15 @@
         // If one of them is a function, type.getFunctionType() will return it.
         var fnType = type.getFunctionType();
         if(fnType == null) {
-          if (notAFunctionRule && !isFunctionType(type)) addMessage(node, "'" + getNodeName(node) + "' is not a function", notAFunctionRule.severity);
+          if (notAFunctionRule && !isFunctionType(type)) {
+            var parentType = infer.expressionType({node: node.callee.object, state: state});
+            if(parentType == null || parentType.isEmpty()) {
+              // Parent type is empty. This means that this type is a guess at best. To prevent false
+              // warnings, we ignore this case.
+            } else {
+              addMessage(node, "'" + getNodeName(node) + "' is not a function", notAFunctionRule.severity);
+            }
+          }
           return;
         }
         var fnLint = getFunctionLint(fnType);

--- a/test/validate_unknown.js
+++ b/test/validate_unknown.js
@@ -150,6 +150,27 @@ exports['test properties on functions parameters'] = function() {
 	util.assertLint("function test(a) { var len = a.myLength(); };", {
 		messages : [ ]
 	}, null, null, IGNORE_UNUSED_VAR);
+
+  // a is an unkown type, but a.PI is guessed to be a number.
+  // It could also be a function on another object, so should not produce a warning.
+  util.assertLint("var Math = {PI: 3.14}; function test(a) { a.PI(); a.foo()};", {
+      messages : [ ]
+  }, null, null, IGNORE_UNUSED_VAR);
+
+  // a is guessed to be of type Math. Same as above.
+  util.assertLint("var Math = {PI: 3.14}; function test(a) { a.PI(); };", {
+      messages : [ ]
+  }, null, null, IGNORE_UNUSED_VAR);
+
+  // a is known to be of type Math. In this case it should produce an error.
+  util.assertLint("var Math = {PI: 3.14}; function test(a) { a.PI(); }; test(Math);", {
+      "messages": [ {
+          "message": "'PI' is not a function",
+          "from": 44,
+          "to": 46,
+          "severity": "error",
+		      "file": "test1.js"} ]
+  }, null, null, IGNORE_UNUSED_VAR);
 }
 
 exports['test assignment of unknown value'] = function() {


### PR DESCRIPTION
In many cases Tern guesses types, which are not always correct. This sometimes produces false "... is not a function" warnings, for example in cases where there is both a property and a function with the same name (on different objects), and Tern guesses the wrong one.

This change removes the warning when Tern is not sure about the type. See the tests for samples.
