### PR TITLE
Suggest using fn().prop when fn.prop was incorrectly used.

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -4,6 +4,7 @@ exports['test unknown property/identifier validation'] = require('./validate_unk
 exports['test unused variable/function validation'] = require('./validate_unused');
 exports['test RegExp validation'] = require('./validate_regexp');
 exports['test multiple types validation'] = require('./validate_multitypes');
+exports['test function property suggestion'] = require('./suggest_function_properties');
 
 // JSDoc
 //exports['test Assignmement JSDoc validation'] = require('./validate_assignmement_jsdoc');

--- a/test/suggest_function_properties.js
+++ b/test/suggest_function_properties.js
@@ -1,0 +1,32 @@
+var util = require("./util");
+
+var IGNORE_UNUSED_VAR = {"rules" : {"UnusedVariable" : {"severity" : "none"}}};
+
+exports['test function properties'] = function() {
+	util.assertLint("function a() { return {b: 1}; }; var obj = a.b;", {
+		messages : [ {
+		"message": "Unknown property 'b'. Did you mean 'a().b'?",
+			"from": 45,
+			"to": 46,
+			"severity": "warning",
+		  "file": "test1.js"} ]
+	}, [ "ecma5" ], null, IGNORE_UNUSED_VAR);
+
+	util.assertLint("function a() { return {b: 1}; }; var c = {k: a}; var obj = c.k.b;", {
+		messages : [ {
+			"message": "Unknown property 'b'. Did you mean 'k().b'?",
+			"from": 63,
+			"to": 64,
+			"severity": "warning",
+		  "file": "test1.js"} ]
+	}, [ "ecma5" ], null, IGNORE_UNUSED_VAR);
+
+	util.assertLint("Date.now.toFixed();", {
+		messages : [ {
+			"message": "Unknown property 'toFixed'. Did you mean 'now().toFixed'?",
+			"from": 9,
+			"to": 16,
+			"severity": "warning",
+		  "file": "test1.js"} ]
+	}, [ "ecma5" ], null, IGNORE_UNUSED_VAR);
+}


### PR DESCRIPTION
Sample:

    var a = Date.now.toFixed();

Old warning: `Unknown property 'toFixed'`
New warning: `Unknown property 'toFixed'. Did you mean 'now().toFixed'?`

This is only for the case where the property exists on the function return value, but not the function object.